### PR TITLE
Feature/issue-22  refreshToken 기능 추가

### DIFF
--- a/src/main/java/com/spring/nbcijo/config/WebSecurityConfig.java
+++ b/src/main/java/com/spring/nbcijo/config/WebSecurityConfig.java
@@ -65,13 +65,13 @@ public class WebSecurityConfig {
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                 .permitAll() // resources 접근 허용 설정
                 .requestMatchers("/").permitAll() // 메인 페이지 요청 허가
-                .requestMatchers("/api/user/**").permitAll() // '/api/user/'로 시작하는 요청 모두 접근 허가
+                .requestMatchers("/auth/**").permitAll() // '/api/user/'로 시작하는 요청 모두 접근 허가
                 .anyRequest().permitAll() // 그 외 모든 요청 인증처리
         );
 
         http.formLogin((formLogin) ->
             formLogin
-                .loginPage("/api/user/login-page").permitAll()
+                .loginPage("/auth/login-page").permitAll()
         );
 
         // 필터 관리

--- a/src/main/java/com/spring/nbcijo/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/spring/nbcijo/security/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import com.spring.nbcijo.dto.request.LoginRequestDto;
 import com.spring.nbcijo.entity.UserRoleEnum;
 import com.spring.nbcijo.jwt.JwtUtil;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -46,17 +47,41 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     @Override
     protected void successfulAuthentication(HttpServletRequest request,
-        HttpServletResponse response, FilterChain chain, Authentication authResult) {
+        HttpServletResponse response, FilterChain chain, Authentication authResult)
+        throws IOException {
         String username = ((UserDetailsImpl) authResult.getPrincipal()).getUsername();
         UserRoleEnum role = ((UserDetailsImpl) authResult.getPrincipal()).getUser().getRole();
-
+        // AccessToken 생성
         String token = jwtUtil.createToken(username, role);
+
+        // RefreshToken 생성
+        String refreshToken = jwtUtil.createRefreshToken(username, role);
+
+        // AccessToken을 Response Header에 추가
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, token);
+
+        // RefreshToken을 쿠키에 담아 Response에 추가
+        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+        refreshTokenCookie.setMaxAge(
+            (int) (jwtUtil.REFRESH_TOKEN_TIME / 1000)); // 쿠키 유효 기간 설정 (초 단위)
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setPath("/");
+        response.addCookie(refreshTokenCookie);
+
+        // 응답 메시지를 JSON 형식으로 작성
+        String jsonResponse = "{\"message\": \"로그인 성공\"}";
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(jsonResponse);
     }
 
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request,
-        HttpServletResponse response, AuthenticationException failed) {
-        response.setStatus(401);
+        HttpServletResponse response, AuthenticationException failed) throws IOException {
+        // 응답 메시지를 JSON 형식으로 작성
+        String jsonResponse = "{\"message\": \"회원을 찾을 수 없습니다.\"}";
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(jsonResponse);
     }
 }


### PR DESCRIPTION
### ✅ PR 종류

- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 테스트
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

--- 

### ⛏ 반영 브랜치

- feat/isuue-22-> dev

---

### 📑 변경 사항

- refreshToken 구현
- refreshToken으로 accessToken 생성기능

---

### 👀 중요하게 확인할 부분

- WebSecurityConfig에서 .anyRequest().permitAll()부분 수정하면 안됩니다. jwt 인증 필요 없는거 먼저 예외처리해서 .anyRequest().authenticated()으로 바꾸시면 예외처리된거 다음 필터로 못넘어가서 에러 발생합니다
- /my를 제외한 get 요청, 회원 로그인 및 회원가입 부분 jwt 인증 예외처리 되어있습니다
- 리펙토링 많이 하긴 했지만 이해 안되시는 부분 있으시면 저한테 물어보세요
- 토큰 검증할 때 비효율적으로 검증하는 부분이 있는데 Jwts.parserBuilder()를 사용하면 토큰이 만료되었을 때 바로 exception을 해버려서 만료된 토큰을 확인하기 위해서 매소드와 조건문을 나누었습니다
---

### ❗ 관련 이슈

close 
